### PR TITLE
fix(test): Update expected total from 45 to 46 after DOTPosted field addition

### DIFF
--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -566,7 +566,7 @@ func TestTransformToVideoListItems(t *testing.T) {
 		assert.Equal(t, "draft", video.Status)
 		// Expected: Basic video has minimal completion values
 		assert.LessOrEqual(t, video.Progress.Completed, video.Progress.Total)
-		assert.Equal(t, 45, video.Progress.Total)
+		assert.Equal(t, 46, video.Progress.Total)
 	})
 
 	t.Run("edge cases and missing fields", func(t *testing.T) {
@@ -592,7 +592,7 @@ func TestTransformToVideoListItems(t *testing.T) {
 		assert.Equal(t, "test", video.Category)
 		assert.Equal(t, "draft", video.Status) // Not published
 		assert.LessOrEqual(t, video.Progress.Completed, video.Progress.Total)
-		assert.Equal(t, 45, video.Progress.Total)
+		assert.Equal(t, 46, video.Progress.Total)
 	})
 
 	t.Run("status derivation logic", func(t *testing.T) {


### PR DESCRIPTION
### **User description**
## Summary

Fixes failing tests after the DOTPosted field was added to Post-Publish Details tracking in PR #211.

## Changes

- Updated test expectations in `TestTransformToVideoListItems` from 45 to 46 total tasks
- The `CalculatePostPublishProgress` method now includes the `DOTPosted` field, increasing the total count from 9 to 10 post-publish tasks
- This brings the overall total progress count from 45 to 46 tasks

## Context

After merging PR #211 which added the DOTPosted field as the first option in Post-Publish Details, the API tests began failing because they expected a total of 45 tasks but were getting 46.

The DOTPosted field is correctly included in the progress calculation, so the tests needed to be updated to reflect the new expected total.

## Testing

- ✅ All tests now pass
- ✅ Verified that the new total of 46 is correct (36 + 10 post-publish tasks including DOTPosted)
- ✅ No functional changes, only test expectations updated

## Files Changed

- `internal/api/handlers_test.go`: Updated expected total from 45 to 46

This is a straightforward test fix with no risk to existing functionality.


___

### **PR Type**
Tests


___

### **Description**
- Updated test expectations to reflect new total progress count

- Changed expected `video.Progress.Total` from 45 to 46 in two test cases

- Aligns tests with recent addition of `DOTPosted` field in progress calculation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>handlers_test.go</strong><dd><code>Adjust test assertions for new progress total</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/api/handlers_test.go

<li>Updated two assertions to expect 46 instead of 45 for <br><code>video.Progress.Total</code><br> <li> Ensured tests match new progress calculation logic after field <br>addition


</details>


  </td>
  <td><a href="https://github.com/vfarcic/youtube-automation/pull/212/files#diff-f9a3f7afa4f9b5d69c6c491ea474022780a86ec92bf8bb3eab420fd5aaa494ce">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>