### PR TITLE
Fix(api): Preserve Video Display Name on Update

### DIFF
--- a/docs/api-manual-testing.md
+++ b/docs/api-manual-testing.md
@@ -210,15 +210,18 @@ curl -X GET "http://localhost:8080/api/videos/list?phase=invalid"
 
 #### Get Specific Video Details
 ```bash
-curl -X GET "http://localhost:8080/api/videos/test-api-video?category=test-category"
+curl -X GET "http://localhost:8080/api/videos/my-video-filename?category=test-category"
 ```
+
+**Note on Video IDs and Names:** The `{videoName}` in the URL path (e.g., `my-video-filename`) is the video's unique ID and must match its YAML filename (e.g., `my-video-filename.yaml`). This ID is used for all API lookups. The `name` field inside the returned JSON is the video's separate display name (e.g., "My Video Display Name"), which is read from the file and is independent of the filename ID.
+
 Expected response:
 ```json
 {
   "video": {
-    "name": "test-api-video",
+    "name": "My Video Display Name",
     "category": "test-category",
-    "path": "manuscript/test-category/test-api-video.yaml",
+    "path": "manuscript/test-category/my-video-filename.yaml",
     "init": {"completed": 0, "total": 8},
     "work": {"completed": 0, "total": 11},
     "define": {"completed": 0, "total": 9},

--- a/internal/service/video_service.go
+++ b/internal/service/video_service.go
@@ -275,7 +275,9 @@ func (s *VideoService) GetVideo(name, category string) (storage.Video, error) {
 		return storage.Video{}, fmt.Errorf("failed to get video %s: %w", name, err)
 	}
 
-	video.Name = name
+	if video.Name == "" {
+		video.Name = name
+	}
 	video.Category = category
 	video.Path = videoPath
 

--- a/internal/service/video_service_test.go
+++ b/internal/service/video_service_test.go
@@ -171,6 +171,35 @@ func TestVideoService_GetVideo(t *testing.T) {
 	}
 }
 
+func TestVideoService_GetVideo_PreservesNameFromFile(t *testing.T) {
+	service, tempDir, cleanup := setupTestVideoService(t)
+	defer cleanup()
+
+	videoFileName := "my-video-file"
+	videoDisplayName := "My Video Display Name"
+	category := "test-category"
+
+	// Create a video file with a different name in content
+	videoContent := "name: \"" + videoDisplayName + "\""
+	videoPath := filepath.Join(tempDir, "manuscript", category, videoFileName+".yaml")
+	err := os.WriteFile(videoPath, []byte(videoContent), 0644)
+	require.NoError(t, err)
+
+	// Create index entry for the video
+	index, err := service.yamlStorage.GetIndex()
+	require.NoError(t, err)
+	index = append(index, storage.VideoIndex{Name: videoFileName, Category: category})
+	err = service.yamlStorage.WriteIndex(index)
+	require.NoError(t, err)
+
+	// Get the video
+	video, err := service.GetVideo(videoFileName, category)
+	require.NoError(t, err)
+
+	// Assert that the display name from the file is preserved
+	assert.Equal(t, videoDisplayName, video.Name)
+}
+
 func TestVideoService_UpdateVideo(t *testing.T) {
 	service, _, cleanup := setupTestVideoService(t)
 	defer cleanup()

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -217,7 +217,7 @@ paths:
         - name: videoName
           in: path
           required: true
-          description: The name of the video
+          description: The file-based ID of the video (e.g., 'my-video-file-name')
           schema:
             type: string
             example: "my-video"
@@ -258,7 +258,7 @@ paths:
         - name: videoName
           in: path
           required: true
-          description: The name of the video to update
+          description: The file-based ID of the video (e.g., 'my-video-file-name')
           schema:
             type: string
             example: "my-video"
@@ -298,7 +298,7 @@ paths:
         - name: videoName
           in: path
           required: true
-          description: The name of the video to delete
+          description: The file-based ID of the video (e.g., 'my-video-file-name')
           schema:
             type: string
             example: "my-video"
@@ -336,7 +336,7 @@ paths:
         - name: videoName
           in: path
           required: true
-          description: The name of the video to move
+          description: The file-based ID of the video (e.g., 'my-video-file-name')
           schema:
             type: string
             example: "my-video"
@@ -388,7 +388,7 @@ paths:
         - name: videoName
           in: path
           required: true
-          description: The name of the video
+          description: The file-based ID of the video (e.g., 'my-video-file-name')
           schema:
             type: string
             example: "my-video"
@@ -430,7 +430,7 @@ paths:
         - name: videoName
           in: path
           required: true
-          description: The name of the video
+          description: The file-based ID of the video (e.g., 'my-video-file-name')
           schema:
             type: string
             example: "my-video"
@@ -472,7 +472,7 @@ paths:
         - name: videoName
           in: path
           required: true
-          description: The name of the video
+          description: The file-based ID of the video (e.g., 'my-video-file-name')
           schema:
             type: string
             example: "my-video"
@@ -514,7 +514,7 @@ paths:
         - name: videoName
           in: path
           required: true
-          description: The name of the video
+          description: The file-based ID of the video (e.g., 'my-video-file-name')
           schema:
             type: string
             example: "my-video"
@@ -556,7 +556,7 @@ paths:
         - name: videoName
           in: path
           required: true
-          description: The name of the video
+          description: The file-based ID of the video (e.g., 'my-video-file-name')
           schema:
             type: string
             example: "my-video"
@@ -598,7 +598,7 @@ paths:
         - name: videoName
           in: path
           required: true
-          description: The name of the video
+          description: The file-based ID of the video (e.g., 'my-video-file-name')
           schema:
             type: string
             example: "my-video"
@@ -987,12 +987,11 @@ components:
       properties:
         name:
           type: string
-          description: The name of the video
-          example: "my-awesome-video"
+          description: The canonical display name of the video, read from the file
+          example: "My Awesome Video"
         index:
           type: integer
           description: The index number of the video
-          example: 1
         path:
           type: string
           description: The file system path to the video


### PR DESCRIPTION
This PR fixes a bug where the video service was incorrectly overwriting the canonical display name of a video with its file-based ID during an update.

The fix ensures that the display name from the YAML file is preserved.

Changes included:
- Corrected the logic in `video_service.go`.
- Added a new unit test in `video_service_test.go` to cover this specific scenario and prevent regressions.
- Clarified the distinction between file-based IDs and display names in the OpenAPI specification (`openapi.yaml`).
- Updated the manual testing guide (`docs/api-manual-testing.md`) with a note explaining the behavior.