### PR TITLE
Include video title in sponsor email subject

### DIFF
--- a/internal/app/menu_handler.go
+++ b/internal/app/menu_handler.go
@@ -1113,7 +1113,7 @@ func (m *MenuHandler) handleEditVideoPhases(videoToEdit storage.Video) error {
 						updatedVideo.NotifiedSponsors = false // Revert intent
 					} else {
 						emailService := notification.NewEmail(configuration.GlobalSettings.Email.Password)
-						emailService.SendSponsors(configuration.GlobalSettings.Email.From, updatedVideo.Sponsorship.Emails, updatedVideo.VideoId, updatedVideo.Sponsorship.Amount)
+						emailService.SendSponsors(configuration.GlobalSettings.Email.From, updatedVideo.Sponsorship.Emails, updatedVideo.VideoId, updatedVideo.Sponsorship.Amount, updatedVideo.Title)
 						fmt.Println(m.confirmationStyle.Render("Sponsor notification email sent."))
 					}
 				} else if originalNotifiedSponsors && !updatedVideo.NotifiedSponsors { // User deselected in this phase

--- a/internal/notification/email.go
+++ b/internal/notification/email.go
@@ -141,14 +141,14 @@ func (e *Email) SendEdit(from, to string, video storage.Video) error {
 	return nil
 }
 
-func generateSponsorsEmailContent(videoID, sponsorshipPrice string) (subject, body string) {
-	subject = "DevOps Toolkit Video Sponsorship"
+func generateSponsorsEmailContent(videoID, sponsorshipPrice, videoTitle string) (subject, body string) {
+	subject = fmt.Sprintf("DevOps Toolkit Video Sponsorship - %s", videoTitle)
 	body = fmt.Sprintf("Hi,\n<br><br>The video has just been released and is available at https://youtu.be/%s. Please let me know what you think or if you have any questions.\n<br><br>I'll send the invoice for %s in a separate message.\n", videoID, sponsorshipPrice)
 	return subject, body
 }
 
-func (e *Email) SendSponsors(from, to string, videoID, sponsorshipPrice string) error {
-	subject, body := generateSponsorsEmailContent(videoID, sponsorshipPrice)
+func (e *Email) SendSponsors(from, to string, videoID, sponsorshipPrice, videoTitle string) error {
+	subject, body := generateSponsorsEmailContent(videoID, sponsorshipPrice, videoTitle)
 	toArray := strings.Split(to, ",")
 	toArray = append(toArray, configuration.GlobalSettings.Email.FinanceTo)
 	err := e.Send(from, toArray, subject, body, "")

--- a/internal/notification/email_test.go
+++ b/internal/notification/email_test.go
@@ -414,6 +414,7 @@ func TestEmailFunctionality(t *testing.T) {
 			video.Sponsorship.Emails,
 			video.VideoId,
 			video.Sponsorship.Amount,
+			video.Title,
 		)
 		if err != nil {
 			t.Fatalf("SendSponsors failed: %v", err)
@@ -427,8 +428,9 @@ func TestEmailFunctionality(t *testing.T) {
 
 		// Verify message contents
 		msg := messages[0]
-		if !strings.Contains(msg.Subject, "DevOps Toolkit Video Sponsorship") {
-			t.Errorf("Expected subject to contain 'DevOps Toolkit Video Sponsorship', got '%s'", msg.Subject)
+		expectedSubject := fmt.Sprintf("DevOps Toolkit Video Sponsorship - %s", video.Title)
+		if !strings.Contains(msg.Subject, expectedSubject) {
+			t.Errorf("Expected subject to contain '%s', got '%s'", expectedSubject, msg.Subject)
 		}
 
 		if !strings.Contains(msg.Body, video.VideoId) {
@@ -702,6 +704,7 @@ func TestGenerateSponsorsEmailContent(t *testing.T) {
 		name             string
 		videoID          string
 		sponsorshipPrice string
+		videoTitle       string
 		expectSubject    string
 		expectBody       string
 	}{
@@ -709,21 +712,23 @@ func TestGenerateSponsorsEmailContent(t *testing.T) {
 			name:             "Basic sponsor email",
 			videoID:          "dQw4w9WgXcQ",
 			sponsorshipPrice: "$1000",
-			expectSubject:    "DevOps Toolkit Video Sponsorship",
+			videoTitle:       "How to Deploy Kubernetes Apps",
+			expectSubject:    "DevOps Toolkit Video Sponsorship - How to Deploy Kubernetes Apps",
 			expectBody:       "Hi,\n<br><br>The video has just been released and is available at https://youtu.be/dQw4w9WgXcQ. Please let me know what you think or if you have any questions.\n<br><br>I'll send the invoice for $1000 in a separate message.\n",
 		},
 		{
 			name:             "Sponsor email with different price",
 			videoID:          "abcdef12345",
 			sponsorshipPrice: "€500 (EUR)",
-			expectSubject:    "DevOps Toolkit Video Sponsorship",
+			videoTitle:       "Docker Containers Explained",
+			expectSubject:    "DevOps Toolkit Video Sponsorship - Docker Containers Explained",
 			expectBody:       "Hi,\n<br><br>The video has just been released and is available at https://youtu.be/abcdef12345. Please let me know what you think or if you have any questions.\n<br><br>I'll send the invoice for €500 (EUR) in a separate message.\n",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			subject, body := generateSponsorsEmailContent(tt.videoID, tt.sponsorshipPrice)
+			subject, body := generateSponsorsEmailContent(tt.videoID, tt.sponsorshipPrice, tt.videoTitle)
 			assert.Equal(t, tt.expectSubject, subject)
 			// Direct comparison for body as it's simpler and less prone to formatting issues here
 			assert.Equal(t, tt.expectBody, body)


### PR DESCRIPTION
## Summary
- Update email subject from "DevOps Toolkit Video Sponsorship" to "DevOps Toolkit Video Sponsorship - TITLE"
- Makes sponsor notifications more informative by including the specific video title

## Test plan
- [x] All existing tests pass
- [x] Updated test cases verify new email subject format
- [x] Build completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)