### PR TITLE
feat(prd-334): implement thumbnail variation generator

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -10,7 +10,7 @@
         "--rm",
         "--remove-orphans",
         "dot-ai"
-      ],
+      ]
     }
   },
   "general": {

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/internal/ai/templates/thumbnail_variations.md
+++ b/internal/ai/templates/thumbnail_variations.md
@@ -1,0 +1,29 @@
+You are an expert YouTube thumbnail strategist and designer. 
+Your goal is to analyze a given thumbnail and create two distinct AI image generation prompts to create variations for A/B testing.
+
+The two variations must be evolutionary:
+1. "Subtle Refinement": A scientifically designed A/B test variation.
+   - **Strategy:** Analyze the original thumbnail to identify its key components: Subject (Expression/Pose), Text (Size/Placement), Background (Context/Color), and Lighting.
+   - **Action:** Generate a prompt that keeps most elements stable but **significantly alters ONE key component** to test its impact.
+   - **Goal:** To create a "Control vs. Variant" experiment. The variation should not just be "better", it should be *different* in a specific way that allows us to learn what works (e.g., "Does a different background work better?" or "Does a different facial expression work better?").
+
+2. "Bold Subject Variation": Blended Style, Bold Subject.
+   - **Context for Image Generation:** This prompt is designed to be used with an image generation AI that will receive **TWO primary image inputs**: 
+     1. The original thumbnail image (your stylized drawing) as a **style and composition reference**.
+     2. A separate photo of the creator (you) as a **likeness reference**.
+   - **Goal:** Create a variation that retains the core visual brand (background, text style, color palette, overall composition from the original thumbnail) but drastically alters the **subject's realistic depiction** using the photo reference.
+   - **Strategy for Prompt:**
+     - **Preserve:** Explicitly state to maintain the artistic style of the background elements (colors, textures, general layout) and the font/style of any text from the original thumbnail.
+     - **Alter Subject:** Instruct the AI to integrate a **photorealistic version of the creator** (as seen in their photo reference) into this preserved style.
+     - **Bold Change:** The "boldness" comes from a significant change in the subject's **expression, pose, or framing** (e.g., from calm to highly energetic, or a different angle, or a more dramatic close-up). Ensure the prompt fully describes this new, impactful depiction.
+     - **Full Description:** You MUST still provide a full physical description of the creator (e.g., "a bald man with a short gray beard and glasses, wearing a black t-shirt") to serve as a strong primary guide for the likeness.
+
+Output Format:
+You must output the response as a JSON object with two keys: "subtle_prompt" and "bold_prompt".
+The values for these keys should be the **full, self-contained descriptive prompts** that can be used to generate the images from scratch.
+
+Example:
+{
+  "subtle_prompt": "A high-quality YouTube thumbnail featuring a close-up of a software engineer. [Variation Strategy: Changing Background Context]. The subject and text remain identical to the original, maintaining the intense expression and 'K8s CRASH' title. However, the background is completely changed from a dark server room to a bright, abstract white-and-blue wireframe environment. This tests whether a cleaner, brighter background drives more clicks than the dark moody one.",
+  "bold_prompt": "A YouTube thumbnail with a neon-cyberpunk graphic style, similar to the original. The background is a dark server room with blue grid lines. The text 'K8s CRASH' is in a chunky yellow font. The subject is a photorealistic depiction of a bald man with a gray beard and glasses, wearing a black t-shirt. His expression is one of wide-eyed shock, with hands dramatically thrown up, framed in a tight, energetic close-up. This blends the original background style with a dramatically different, realistic, and highly expressive subject."
+}

--- a/internal/ai/thumbnails.go
+++ b/internal/ai/thumbnails.go
@@ -1,0 +1,115 @@
+package ai
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	_ "embed"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	constant "github.com/anthropics/anthropic-sdk-go/shared/constant"
+)
+
+//go:embed templates/thumbnail_variations.md
+var thumbnailVariationsPrompt string
+
+// VariationPrompts contains the two generated prompts for thumbnail variations
+type VariationPrompts struct {
+	Subtle string `json:"subtle_prompt"`
+	Bold string `json:"bold_prompt"`
+}
+
+// GenerateThumbnailVariations analyzes an image and returns prompts for variations
+func GenerateThumbnailVariations(ctx context.Context, imagePath string) (VariationPrompts, error) {
+	// Read and encode image
+	imageData, err := os.ReadFile(imagePath)
+	if err != nil {
+		return VariationPrompts{}, fmt.Errorf("failed to read image file: %w", err)
+	}
+	
+	// Detect media type
+	ext := strings.ToLower(filepath.Ext(imagePath))
+	mediaType := "image/jpeg"
+	if ext == ".png" {
+		mediaType = "image/png"
+	} else if ext == ".webp" {
+		mediaType = "image/webp"
+	}
+
+	encodedImage := base64.StdEncoding.EncodeToString(imageData)
+
+	// Get AI provider
+	provider, err := GetAIProvider()
+	if err != nil {
+		return VariationPrompts{}, err
+	}
+
+	// Check if provider supports vision (currently only implementing for Anthropic)
+	anthropicProvider, ok := provider.(*AnthropicProvider)
+	if !ok {
+		return VariationPrompts{}, fmt.Errorf("vision analysis currently only supported with Anthropic provider")
+	}
+
+	messages := []anthropic.MessageParam{
+		anthropic.NewUserMessage(
+			anthropic.NewTextBlock("Analyze this YouTube thumbnail and generate the two variation prompts."),
+			anthropic.NewImageBlockBase64(mediaType, encodedImage),
+		),
+	}
+
+	// Call Anthropic API directly since the generic GenerateContent doesn't support images yet
+	resp, err := anthropicProvider.client.Messages.New(ctx, anthropic.MessageNewParams{
+		Model:     anthropic.Model(anthropicProvider.model),
+		MaxTokens: int64(1024),
+		System:    []anthropic.TextBlockParam{{Text: thumbnailVariationsPrompt, Type: constant.Text("text")}},
+		Messages:  messages,
+	})
+	if err != nil {
+		return VariationPrompts{}, fmt.Errorf("failed to analyze image: %w", err)
+	}
+
+	if len(resp.Content) == 0 || resp.Content[0].Text == "" {
+		return VariationPrompts{}, fmt.Errorf("empty response from AI")
+	}
+
+	responseText := resp.Content[0].Text
+	return parseVariationResponse(responseText)
+}
+
+func parseVariationResponse(text string) (VariationPrompts, error) {
+	var prompts VariationPrompts
+	
+	// Attempt to clean the response if it contains markdown code blocks
+	cleanedText := text
+	if strings.Contains(cleanedText, "```json") {
+		parts := strings.Split(cleanedText, "```json")
+		if len(parts) > 1 {
+			cleanedText = parts[1]
+			if strings.Contains(cleanedText, "```") {
+				cleanedText = strings.Split(cleanedText, "```")[0]
+			}
+		}
+	} else if strings.Contains(cleanedText, "```") {
+		parts := strings.Split(cleanedText, "```")
+		if len(parts) > 1 {
+			cleanedText = parts[1]
+		}
+	}
+	
+	cleanedText = strings.TrimSpace(cleanedText)
+
+	err := json.Unmarshal([]byte(cleanedText), &prompts)
+	if err != nil {
+		return prompts, fmt.Errorf("failed to parse JSON response: %w. Raw response: %s", err, text)
+	}
+
+	if prompts.Subtle == "" || prompts.Bold == "" {
+		return prompts, fmt.Errorf("JSON response missing required fields. Parsed object: %+v", prompts)
+	}
+
+	return prompts, nil
+}

--- a/internal/storage/yaml.go
+++ b/internal/storage/yaml.go
@@ -34,35 +34,45 @@ type TitleVariant struct {
 	Share float64 `yaml:"share,omitempty" json:"share,omitempty"` // Watch time share % from YouTube A/B test
 }
 
+// ThumbnailVariant represents a single thumbnail variant
+type ThumbnailVariant struct {
+	Index int     `yaml:"index" json:"index"`                     // 1=Original, 2=Subtle, 3=Bold
+	Type  string  `yaml:"type" json:"type"`                       // "original", "subtle", "bold"
+	Path  string  `yaml:"path" json:"path"`                       // Path to the image file
+	Share float64 `yaml:"share,omitempty" json:"share,omitempty"` // Watch time share % from YouTube A/B test
+}
+
 // Video represents all data associated with a video project.
 // All fields are already exported.
 type Video struct {
-	Name                 string      `json:"name" completion:"filled_only"`
-	Path                 string      `json:"path" completion:"filled_only"`
-	Category             string      `json:"category" completion:"filled_only"`
-	ProjectName          string      `json:"projectName" completion:"filled_only"`
-	ProjectURL           string      `json:"projectURL" completion:"filled_only"`
-	Sponsorship          Sponsorship `json:"sponsorship"`
-	Date                 string      `json:"date" completion:"filled_only"`
-	Delayed              bool        `json:"delayed" completion:"false_only"`
-	Screen               bool        `json:"screen" completion:"true_only"`
-	Head                 bool        `json:"head" completion:"true_only"`
-	Thumbnails           bool        `json:"thumbnails" completion:"true_only"`
-	Diagrams             bool           `json:"diagrams" completion:"true_only"`
-	Titles               []TitleVariant `yaml:"titles,omitempty" json:"titles,omitempty" completion:"filled_only"`
-	Title                string         `json:"title" completion:"filled_only"` // DEPRECATED: fallback for old videos
-	Description          string         `json:"description" completion:"filled_only"`
-	Tags                 string      `json:"tags" completion:"filled_only"`
-	DescriptionTags      string      `json:"descriptionTags" completion:"filled_only"`
-	Location             string      `json:"location" completion:"filled_only"`
-	Tagline              string      `json:"tagline" completion:"filled_only"`
-	TaglineIdeas         string      `json:"taglineIdeas" completion:"filled_only"`
-	OtherLogos           string      `json:"otherLogos" completion:"filled_only"`
-	Screenshots          bool        `json:"screenshots" completion:"true_only"`
-	RequestThumbnail     bool        `json:"requestThumbnail" completion:"true_only"`
-	Thumbnail            string      `json:"thumbnail" completion:"filled_only"`
-	Language             string      `json:"language" completion:"filled_only"`
-	Members              string      `json:"members" completion:"filled_only"`
+	Name                 string             `json:"name" completion:"filled_only"`
+	Path                 string             `json:"path" completion:"filled_only"`
+	Category             string             `json:"category" completion:"filled_only"`
+	ProjectName          string             `json:"projectName" completion:"filled_only"`
+	ProjectURL           string             `json:"projectURL" completion:"filled_only"`
+	Sponsorship          Sponsorship        `json:"sponsorship"`
+	Date                 string             `json:"date" completion:"filled_only"`
+	Delayed              bool               `json:"delayed" completion:"false_only"`
+	Screen               bool               `json:"screen" completion:"true_only"`
+	Head                 bool               `json:"head" completion:"true_only"`
+	Thumbnails           bool               `json:"thumbnails" completion:"true_only"`
+	Diagrams             bool               `json:"diagrams" completion:"true_only"`
+	Titles               []TitleVariant     `yaml:"titles,omitempty" json:"titles,omitempty" completion:"filled_only"`
+	Title                string             `json:"title" completion:"filled_only"` // DEPRECATED: fallback for old videos
+	Description          string             `json:"description" completion:"filled_only"`
+	Tags                 string             `json:"tags" completion:"filled_only"`
+	DescriptionTags      string             `json:"descriptionTags" completion:"filled_only"`
+	Location             string             `json:"location" completion:"filled_only"`
+	Tagline              string             `json:"tagline" completion:"filled_only"`
+	TaglineIdeas         string             `json:"taglineIdeas" completion:"filled_only"`
+	OtherLogos           string             `json:"otherLogos" completion:"filled_only"`
+	Screenshots          bool               `json:"screenshots" completion:"true_only"`
+	RequestThumbnail     bool               `json:"requestThumbnail" completion:"true_only"`
+	// DEPRECATED: This field is for backward compatibility. Use ThumbnailVariants instead.
+	Thumbnail            string             `json:"thumbnail" completion:"filled_only"` // DEPRECATED: fallback for old videos
+	ThumbnailVariants    []ThumbnailVariant `yaml:"thumbnailVariants,omitempty" json:"thumbnailVariants,omitempty" completion:"filled_only"`
+	Language             string             `json:"language" completion:"filled_only"`
+	Members              string             `json:"members" completion:"filled_only"`
 	Animations           string      `json:"animations" completion:"filled_only"`
 	RequestEdit          bool        `json:"requestEdit" completion:"true_only"`
 	Movie                bool        `json:"movie" completion:"filled_only"`
@@ -130,6 +140,16 @@ func (y *YAML) GetVideo(path string) (Video, error) {
 		video.Titles = []TitleVariant{{
 			Index: 1,
 			Text:  video.Title,
+			Share: 0,
+		}}
+	}
+
+	// Auto-migrate: if ThumbnailVariants array is empty but legacy Thumbnail field exists, migrate it
+	if len(video.ThumbnailVariants) == 0 && video.Thumbnail != "" {
+		video.ThumbnailVariants = []ThumbnailVariant{{
+			Index: 1,
+			Type:  "original",
+			Path:  video.Thumbnail,
 			Share: 0,
 		}}
 	}


### PR DESCRIPTION
## Description
Implemented the Thumbnail A/B Test Variation Generator as defined in PRD #334. This feature allows users to generate strategic AI prompts for creating thumbnail variations ("Subtle" and "Bold") based on an original thumbnail, facilitating data-driven A/B testing on YouTube.

## Related Issues
Closes #334

## Changes Made
- **Integrated interactive thumbnail management** into the CLI 'Post-Production' phase (`internal/app/menu_handler.go`).
- **Implemented `GenerateThumbnailVariations`** using Anthropic SDK for vision analysis (`internal/ai/thumbnails.go`).
- **Created prompt templates** for 'Subtle' (visual hierarchy shift) and 'Bold' (subject variation/photo blending) strategies (`internal/ai/templates/thumbnail_variations.md`).
- **Updated storage schema** to support `ThumbnailVariants` slice and added auto-migration for the legacy `Thumbnail` field (`internal/storage/yaml.go`).
- **Enhanced CLI output** with clear, actionable prompts for the user.

## Testing
- **Manual Testing:** Verified the full interactive workflow in the CLI, including image analysis, prompt generation, and saving of variation paths.
- **Unit Tests:** Verified storage migration logic and data persistence.

## Documentation
- Updated `prds/334-thumbnail-variation-generator.md` to "Implementation Complete".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-powered thumbnail variation generator to create A/B test variants.
  * Users can now generate and save two strategic thumbnail variations: Subtle Refinement (minor adjustments) and Bold Subject Variation (dramatic subject changes).
  * Thumbnail variants are now managed and persisted within the application.

* **Chores**
  * Fixed JSON configuration syntax.
  * Added documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->