### PR TITLE
fix(prd-401): hotfix TypeScript test types after PR #403 merge

### DIFF
--- a/web/src/test/ThumbnailGenerateButton.test.tsx
+++ b/web/src/test/ThumbnailGenerateButton.test.tsx
@@ -8,6 +8,14 @@ import { mockVideo } from './handlers';
 import { ThumbnailGenerateButton } from '../components/forms/ThumbnailGenerateButton';
 import type { VideoResponse } from '../api/types';
 
+// Shape of the JSON body POSTed to /api/videos/:videoName/thumbnail-config.
+// Mirrors the input to useSaveThumbnailConfig in src/api/hooks.ts.
+interface ThumbnailConfigSaveBody {
+  tagline?: string;
+  illustration?: string;
+  photoRealisticSubject?: string;
+}
+
 function renderButton(videoOverrides: Partial<VideoResponse> = {}) {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -223,14 +231,18 @@ describe('ThumbnailGenerateButton', () => {
   });
 
   it('persists user-typed subject via save endpoint', async () => {
-    let capturedBody: { photoRealisticSubject?: string } | null = null;
+    // Wrap captured value in an object so the closure-set body survives
+    // TypeScript's literal-null narrowing of a plain `let x: T | null = null`.
+    // tsc -b otherwise narrows the variable to `never` at the assertion site
+    // because it doesn't track the msw handler reassignment.
+    const captured: { body?: ThumbnailConfigSaveBody } = {};
     server.use(
       http.post('/api/videos/:videoName/thumbnail-config', async ({ request }) => {
-        capturedBody = (await request.json()) as { photoRealisticSubject?: string };
+        captured.body = (await request.json()) as ThumbnailConfigSaveBody;
         return HttpResponse.json({
           tagline: 'Test Tagline',
           illustration: '',
-          photoRealisticSubject: capturedBody?.photoRealisticSubject ?? '',
+          photoRealisticSubject: captured.body?.photoRealisticSubject ?? '',
         });
       }),
     );
@@ -244,9 +256,9 @@ describe('ThumbnailGenerateButton', () => {
     await userEvent.click(saveBtn);
 
     await waitFor(() => {
-      expect(capturedBody).not.toBeNull();
+      expect(captured.body).toBeDefined();
     });
-    expect(capturedBody?.photoRealisticSubject).toBe('a small white rabbit holding a checklist');
+    expect(captured.body?.photoRealisticSubject).toBe('a small white rabbit holding a checklist');
   });
 
   it('does not show "Save subject" button when input matches the stored subject', () => {
@@ -378,16 +390,17 @@ describe('ThumbnailGenerateButton', () => {
 
   it('auto-saves typed subject before generate when input differs from stored', async () => {
     const callOrder: string[] = [];
-    let capturedSaveBody: { photoRealisticSubject?: string } | null = null;
+    // See note above (persists user-typed subject test) on why we wrap.
+    const captured: { body?: ThumbnailConfigSaveBody } = {};
 
     server.use(
       http.post('/api/videos/:videoName/thumbnail-config', async ({ request }) => {
-        capturedSaveBody = (await request.json()) as { photoRealisticSubject?: string };
+        captured.body = (await request.json()) as ThumbnailConfigSaveBody;
         callOrder.push('save');
         return HttpResponse.json({
           tagline: 'Test Tagline',
           illustration: '',
-          photoRealisticSubject: capturedSaveBody?.photoRealisticSubject ?? '',
+          photoRealisticSubject: captured.body?.photoRealisticSubject ?? '',
         });
       }),
       http.post('/api/thumbnails/generate', () => {
@@ -414,7 +427,7 @@ describe('ThumbnailGenerateButton', () => {
     await waitFor(() => {
       expect(callOrder).toEqual(['save', 'generate']);
     });
-    expect(capturedSaveBody?.photoRealisticSubject).toBe('a small white rabbit');
+    expect(captured.body?.photoRealisticSubject).toBe('a small white rabbit');
   });
 
   it('does NOT auto-save when input matches the stored subject', async () => {


### PR DESCRIPTION
## Summary
- Hotfix for the TypeScript build break introduced by the PRD 401 merge (#403, commit 515f048). CI on `main` failed `tsc -b` with two TS2339 errors in `web/src/test/ThumbnailGenerateButton.test.tsx`.
- Errors fixed:
  - Line 249: `Property 'photoRealisticSubject' does not exist on type 'never'`
  - Line 417: `Property 'photoRealisticSubject' does not exist on type 'never'`

## Root cause
`let capturedBody: { ... } | null = null` is narrowed by TS5+ control-flow analysis to the literal `null` type — the only assignment TS sees in the visible flow is the initializer; the msw handler closure's reassignment is invisible. The subsequent `x?.foo` on a `null`-narrowed local resolves the property type to `never`.

## Fix
Wrap the captured value in a plain object (`captured.body`). Property accesses on objects are not subject to the same literal-null narrowing, so the body field keeps its declared `ThumbnailConfigSaveBody | undefined` type after the closure mutation. Added a small `ThumbnailConfigSaveBody` interface near the top of the test file mirroring the request body of `useSaveThumbnailConfig`.

No `any` was used.

## Test plan
- [x] `cd web && tsc -b` produces 0 errors
- [x] `cd web && npm test` — 25 files, 200/200 pass
- [x] `go test ./...` — only the pre-existing `internal/configuration/TestSaveTimingRecommendationsWriteError` failure remains (chmod-0444 bypass when running as root; predates this branch and is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)