### PR TITLE
fix: prevent orphan index entries on delete and survive missing YAMLs

### DIFF
--- a/internal/service/video_service.go
+++ b/internal/service/video_service.go
@@ -250,7 +250,11 @@ func (s *VideoService) GetVideosByPhase(phase int) ([]storage.Video, error) {
 		videoPath := s.filesystem.GetFilePath(videoIndex.Category, sanitizedName, "yaml")
 		fullVideo, err := s.yamlStorage.GetVideo(videoPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get video details for %s: %w", videoIndex.Name, err)
+			// Don't fail the whole list for one bad entry — log and skip,
+			// matching GetVideoPhases' behavior. A stranded index entry would
+			// otherwise black-hole every phase listing.
+			slog.Warn("skipping video in phase listing", "name", videoIndex.Name, "category", videoIndex.Category, "error", err)
+			continue
 		}
 		// Always use sanitized name to ensure consistency with filenames
 		fullVideo.Name = s.filesystem.SanitizeName(fullVideo.Name)
@@ -482,9 +486,15 @@ func (s *VideoService) DeleteVideo(name, category string) error {
 		return fmt.Errorf("failed to get index: %w", err)
 	}
 
+	// Compare using sanitized names so legacy index entries written with the
+	// original casing (e.g. "OpenCode") still match the sanitized name the
+	// Web UI sends back ("opencode"). Without this, the YAML/MD files get
+	// removed but the index entry survives, leaving a broken row that makes
+	// /api/videos/list return 500 on the next read.
+	sanitizedTarget := s.filesystem.SanitizeName(name)
 	var updatedIndex []storage.VideoIndex
 	for _, vi := range index {
-		if !(vi.Name == name && vi.Category == category) {
+		if !(s.filesystem.SanitizeName(vi.Name) == sanitizedTarget && vi.Category == category) {
 			updatedIndex = append(updatedIndex, vi)
 		}
 	}

--- a/internal/service/video_service_test.go
+++ b/internal/service/video_service_test.go
@@ -307,6 +307,54 @@ func TestVideoService_DeleteVideo(t *testing.T) {
 	}
 }
 
+// TestVideoService_DeleteVideo_LegacyIndexEntry covers a regression where the
+// index entry was written with the original casing (e.g. "OpenCode") but the
+// Web UI sends back the sanitized form ("opencode"). The filter must match
+// on the sanitized form so the entry doesn't become orphaned.
+func TestVideoService_DeleteVideo_LegacyIndexEntry(t *testing.T) {
+	service, _, cleanup := setupTestVideoService(t)
+	defer cleanup()
+
+	// Create the video the normal way (this writes a sanitized index entry).
+	_, err := service.CreateVideo("legacy", "test-category", "")
+	require.NoError(t, err)
+
+	// Then rewrite the index to simulate a legacy entry with original casing,
+	// as still exists in older data repos.
+	require.NoError(t, service.yamlStorage.WriteIndex([]storage.VideoIndex{
+		{Name: "Legacy", Category: "test-category"},
+	}))
+
+	// The Web UI sends the sanitized form back as the URL param.
+	require.NoError(t, service.DeleteVideo("legacy", "test-category"))
+
+	index, err := service.yamlStorage.GetIndex()
+	require.NoError(t, err)
+	assert.Empty(t, index, "stranded index entry must be removed when name casing differs")
+}
+
+// TestVideoService_GetVideosByPhase_SkipsMissingYAML ensures a stranded index
+// entry pointing at a deleted YAML file does not fail the whole listing — it
+// should be skipped, matching GetVideoPhases' behavior.
+func TestVideoService_GetVideosByPhase_SkipsMissingYAML(t *testing.T) {
+	service, _, cleanup := setupTestVideoService(t)
+	defer cleanup()
+
+	_, err := service.CreateVideo("good", "test-category", "")
+	require.NoError(t, err)
+
+	// Append a stranded index entry whose YAML file does not exist.
+	index, err := service.yamlStorage.GetIndex()
+	require.NoError(t, err)
+	index = append(index, storage.VideoIndex{Name: "ghost", Category: "test-category"})
+	require.NoError(t, service.yamlStorage.WriteIndex(index))
+
+	videos, err := service.GetVideosByPhase(7) // Ideas
+	require.NoError(t, err)
+	assert.Len(t, videos, 1, "missing YAML should be skipped, not crash the listing")
+	assert.Equal(t, "good", videos[0].Name)
+}
+
 func TestVideoService_GetVideosByPhase(t *testing.T) {
 	service, _, cleanup := setupTestVideoService(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

- `DeleteVideo` was leaving stranded `index.yaml` entries when the original-case name in the index (e.g. `OpenCode`) didn't match the sanitized name the Web UI sends back (`opencode`). The YAML/MD files got removed but the index entry survived. The next `/api/videos/list` then 500'd because `GetVideosByPhase` returned an error on the first missing file — taking down every phase listing.
- Sidebar phase counts still loaded (`GetVideoPhases` already `continue`s on load errors), which made the symptom look like a list-only outage.

## Root cause walkthrough

Found this debugging a live "Failed to load videos" in prod. The data repo's `index.yaml` had `{name: OpenCode, category: ai}` but `manuscript/ai/opencode.yaml` was deleted earlier today. The commit that removed the YAML didn't touch `index.yaml` because the filter at `internal/service/video_service.go:487` compared `vi.Name == name` raw. The Web UI's `VideoListItem.Name` is `SanitizeName(fullVideo.Name)`, so older entries written with original casing never matched.

## Changes

- `DeleteVideo`: compare with `SanitizeName` on both sides so legacy entries get cleaned up.
- `GetVideosByPhase`: skip-and-warn on a missing YAML instead of returning an error, matching `GetVideoPhases`. A single bad index row can no longer black-hole every phase listing.
- Two regression tests covering both behaviors.

## Test plan

- [x] `go test ./...` passes locally
- [x] New `TestVideoService_DeleteVideo_LegacyIndexEntry` reproduces the bug (fails on `main`, passes here)
- [x] New `TestVideoService_GetVideosByPhase_SkipsMissingYAML` verifies a stranded entry no longer fails the list
- [ ] After merge + deploy: confirm `/api/videos/list` returns 200 in the cluster and Material Done view loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Video phase listings are now more resilient and will display available videos even if loading an individual video encounters an issue
  * Legacy video index entries are now properly removed during deletion operations, preventing stale entries from persisting

* **Tests**
  * Added regression tests to cover edge cases in video management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vfarcic/youtube-automation/pull/406?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->