### PR TITLE
fix(git): stop untracked files from silently blocking read-time pulls

### DIFF
--- a/internal/api/handlers_categories.go
+++ b/internal/api/handlers_categories.go
@@ -1,11 +1,24 @@
 package api
 
 import (
+	"log/slog"
 	"net/http"
 )
 
 // handleGetCategories returns the available video categories.
+//
+// Categories are derived from the manuscript directories in the data repo, so
+// a category added externally (a new directory pushed to the git remote) only
+// appears once the local clone has pulled it. Best-effort throttled pull
+// refreshes the clone here; failures are logged but never block the response,
+// which is served from the local working copy regardless.
 func (s *Server) handleGetCategories(w http.ResponseWriter, r *http.Request) {
+	if s.gitSync != nil {
+		if err := s.gitSync.PullIfStale(pullOnReadThrottle); err != nil {
+			slog.Warn("categories: git pull failed, serving local copy", "err", err)
+		}
+	}
+
 	categories, err := s.videoService.GetCategories()
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, "failed to get categories", err.Error())

--- a/internal/api/handlers_categories_test.go
+++ b/internal/api/handlers_categories_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -43,6 +44,47 @@ func TestHandleGetCategories(t *testing.T) {
 			if categories[i].Name < categories[i-1].Name {
 				t.Errorf("categories not sorted: %q before %q", categories[i-1].Name, categories[i].Name)
 			}
+		}
+	})
+
+	t.Run("triggers throttled pull when git sync configured", func(t *testing.T) {
+		env := setupTestEnv(t)
+
+		gs := &mockGitSync{}
+		env.server.gitSync = gs
+
+		req := httptest.NewRequest(http.MethodGet, "/api/categories", nil)
+		w := httptest.NewRecorder()
+		env.server.Router().ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+		}
+		if !gs.pullCalled {
+			t.Error("expected PullIfStale to be called so newly-pushed categories appear")
+		}
+		if gs.pullMaxAge != pullOnReadThrottle {
+			t.Errorf("PullIfStale maxAge = %v, want %v", gs.pullMaxAge, pullOnReadThrottle)
+		}
+	})
+
+	t.Run("still serves categories when pull fails", func(t *testing.T) {
+		env := setupTestEnv(t)
+
+		gs := &mockGitSync{pullErr: errors.New("pull failed")}
+		env.server.gitSync = gs
+
+		req := httptest.NewRequest(http.MethodGet, "/api/categories", nil)
+		w := httptest.NewRecorder()
+		env.server.Router().ServeHTTP(w, req)
+
+		// Pull failure must not block the response — local copy is served.
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+		}
+		var categories []service.Category
+		if err := json.NewDecoder(w.Body).Decode(&categories); err != nil {
+			t.Fatalf("decode: %v", err)
 		}
 	})
 

--- a/internal/git/sync.go
+++ b/internal/git/sync.go
@@ -132,8 +132,14 @@ func (s *SyncManager) CommitAndPush(message string) error {
 //
 // The pull is skipped (without error) when:
 //   - The previous attempt was less than maxAge ago.
-//   - The working tree has uncommitted changes.
+//   - The working tree has uncommitted changes to *tracked* files.
 //   - There are local commits that have not been pushed to origin yet.
+//
+// Untracked files are deliberately ignored: transient upload artifacts (e.g.
+// leftover multipart temp files) accumulate in the data directory and would
+// otherwise mark the tree permanently "dirty", silently blocking every
+// read-time pull. They do not affect `git pull --rebase` (rebase only cares
+// about tracked modifications), so they must not gate the pull.
 //
 // Skips return nil because they are expected steady-state conditions, not
 // failures. Actual git failures (network, conflict, etc.) are returned so
@@ -146,8 +152,10 @@ func (s *SyncManager) PullIfStale(maxAge time.Duration) error {
 		return nil
 	}
 
-	// Skip if working tree is dirty — pull --rebase could fail or surprise the user.
-	statusOutput, err := s.executor.Run(s.dataDir, "git", "status", "--porcelain")
+	// Skip if tracked files are modified — pull --rebase could fail or surprise
+	// the user. Untracked files (--untracked-files=no) are ignored on purpose;
+	// see the doc comment above.
+	statusOutput, err := s.executor.Run(s.dataDir, "git", "status", "--porcelain", "--untracked-files=no")
 	if err != nil {
 		s.lastAttempt = s.now()
 		return fmt.Errorf("git status failed: %s: %w", SanitizeOutput(statusOutput, s.token), err)

--- a/internal/git/sync_test.go
+++ b/internal/git/sync_test.go
@@ -271,6 +271,36 @@ func TestPullIfStale_PullsWhenCleanAndNotAhead(t *testing.T) {
 	assert.Contains(t, mock.calls[2].Args, "main")
 }
 
+// TestPullIfStale_IgnoresUntrackedFiles guards the fix for the bug where
+// orphaned upload artifacts (e.g. `multipart-*` temp files) left in the data
+// directory marked the working tree permanently "dirty", causing every
+// read-time pull to be silently skipped. The dirtiness check must exclude
+// untracked files via `--untracked-files=no` so those artifacts cannot gate
+// the pull.
+func TestPullIfStale_IgnoresUntrackedFiles(t *testing.T) {
+	mock := newMockExecutor()
+	// With --untracked-files=no, git reports no changes even though untracked
+	// temp files exist in the working tree.
+	mock.setResult("git status", []byte(""), nil)
+	mock.setResult("git rev-list", []byte("0\n"), nil)
+
+	now := time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
+	sm := newPullTestSyncManager(t, mock, &now)
+
+	require.NoError(t, sm.PullIfStale(10*time.Second))
+
+	// The status check must be invoked with --untracked-files=no so untracked
+	// artifacts are excluded from the dirtiness decision.
+	statusCall := mock.findCall("git status")
+	require.NotNil(t, statusCall)
+	assert.Contains(t, statusCall.Args, "--untracked-files=no",
+		"dirty check must ignore untracked files so temp artifacts don't block pulls")
+
+	// The pull must still happen.
+	require.Len(t, mock.calls, 3)
+	assert.Equal(t, "pull", mock.calls[2].Args[0])
+}
+
 func TestPullIfStale_SkipsWhenWithinThrottleWindow(t *testing.T) {
 	mock := newMockExecutor()
 	mock.setResult("git status", []byte(""), nil)


### PR DESCRIPTION
## Problem

The deployed server sources its manuscript data from a git clone and refreshes it via a throttled `PullIfStale` on reads. In production, newly-pushed content (e.g. a new `manuscript/<category>` directory) never appeared in the running app — the category dropdown stayed stale indefinitely.

## Root cause

`PullIfStale` (`internal/git/sync.go`) skipped the pull whenever the working tree was "dirty", using `git status --porcelain` — which **counts untracked files**. The pod's clone accumulated orphaned upload artifacts (`multipart-*` temp files) in the data directory, so the tree was *permanently* dirty and **every read-time `git pull --rebase` was silently skipped**. The clone froze; external pushes never showed up.

Untracked files don't affect `git pull --rebase`, so they should never gate the pull.

## Fix

- `PullIfStale` now runs `git status --porcelain --untracked-files=no`, so untracked artifacts can't block pulls. Tracked modifications and unpushed-commit checks are unchanged.
- `GET /api/categories` now performs the same best-effort throttled pull as the video-detail handler, so a newly-pushed category appears without needing to open a video first. Pull failures are logged, never block the response.

## Tests

- `TestPullIfStale_IgnoresUntrackedFiles` — regression guard asserting the dirtiness check passes `--untracked-files=no` and the pull proceeds.
- Categories handler: pull is triggered with the read throttle; response is still served when the pull fails.

`go build ./...` and `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)